### PR TITLE
Add optional User API Key support in Doppel integration

### DIFF
--- a/Packs/Doppel/Integrations/Doppel/Doppel.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.py
@@ -44,9 +44,11 @@ class Client(BaseClient):
     For this  implementation, no special attributes defined
     """
 
-    def __init__(self, base_url, api_key):
+    def __init__(self, base_url, api_key, user_api_key=None):
         super().__init__(base_url)
         self._headers = {"accept": "application/json", "x-api-key": api_key}
+        if user_api_key:
+            self._headers["x-user-api-key"] = user_api_key
 
     def get_alert(self, id: str, entity: str) -> dict[str, str]:
         """Return the alert's details when provided the Alert ID or Entity as input
@@ -666,6 +668,7 @@ def get_mapping_fields_command(client: Client, args: dict[str, Any]) -> GetMappi
 def main() -> None:
     """Main function, parses params and runs command functions."""
     api_key = demisto.params().get("credentials", {}).get("password")
+    user_api_key = demisto.params().get("user_credentials", {}).get("password")
 
     # Get the service API URL
     base_url = urljoin(demisto.params()["url"], "/v1")
@@ -691,7 +694,7 @@ def main() -> None:
     demisto.info(f"Command being called is {current_command}")
 
     try:
-        client = Client(base_url=base_url, api_key=api_key)
+        client = Client(base_url=base_url, api_key=api_key, user_api_key=user_api_key)
 
         if current_command in supported_commands_test_module:
             # Calls test_module(client) without args

--- a/Packs/Doppel/Integrations/Doppel/Doppel.yml
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.yml
@@ -21,6 +21,14 @@ configuration:
   required: true
   type: 9
   section: Connect
+- additionalinfo: The User API Key (Optional) to use for connection with Doppel.
+  display: ""
+  displaypassword: User API Key
+  hiddenusername: true
+  name: user_credentials
+  required: false
+  type: 9
+  section: Connect
 - display: Fetch incidents
   name: isFetch
   required: false


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This PR updates the Doppel integration in the Cortex XSOAR content pack to support authentication using an optional User API Key in addition to the existing API Key.


## Must have
- [ ] Tests
- [ ] Documentation 
