### PR TITLE
Add optional User API Key support in Doppel integration

### DIFF
--- a/Packs/Doppel/Integrations/Doppel/Doppel.py
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.py
@@ -44,9 +44,11 @@ class Client(BaseClient):
     For this  implementation, no special attributes defined
     """
 
-    def __init__(self, base_url, api_key):
+    def __init__(self, base_url, api_key, user_api_key=None):
         super().__init__(base_url)
         self._headers = {"accept": "application/json", "x-api-key": api_key}
+        if user_api_key:
+            self._headers["x-user-api-key"] = user_api_key
 
     def get_alert(self, id: str, entity: str) -> dict[str, str]:
         """Return the alert's details when provided the Alert ID or Entity as input
@@ -666,6 +668,7 @@ def get_mapping_fields_command(client: Client, args: dict[str, Any]) -> GetMappi
 def main() -> None:
     """Main function, parses params and runs command functions."""
     api_key = demisto.params().get("credentials", {}).get("password")
+    user_api_key = demisto.params().get("user_credentials", {}).get("password")
 
     # Get the service API URL
     base_url = urljoin(demisto.params()["url"], "/v1")
@@ -691,7 +694,7 @@ def main() -> None:
     demisto.info(f"Command being called is {current_command}")
 
     try:
-        client = Client(base_url=base_url, api_key=api_key)
+        client = Client(base_url=base_url, api_key=api_key, user_api_key=user_api_key)
 
         if current_command in supported_commands_test_module:
             # Calls test_module(client) without args

--- a/Packs/Doppel/Integrations/Doppel/Doppel.yml
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.yml
@@ -21,6 +21,14 @@ configuration:
   required: true
   type: 9
   section: Connect
+- additionalinfo: The User API Key (Optional) to use for connection with Doppel.
+  display: ""
+  displaypassword: User API Key
+  hiddenusername: true
+  name: user_credentials
+  required: false
+  type: 9
+  section: Connect
 - display: Fetch incidents
   name: isFetch
   required: false

--- a/Packs/Doppel/Integrations/Doppel/Doppel.yml
+++ b/Packs/Doppel/Integrations/Doppel/Doppel.yml
@@ -450,7 +450,7 @@ script:
     description: Get remote data from a remote incident. This method does not update the current incident, and should be used for debugging purposes only.
     execution: false
     name: get-remote-data
-  dockerimage: demisto/python3:3.12.8.3296088
+  dockerimage: demisto/python3:3.12.11.4819260
   script: '-'
   type: python
   subtype: python3

--- a/Packs/Doppel/ReleaseNotes/1_0_3.md
+++ b/Packs/Doppel/ReleaseNotes/1_0_3.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Doppel
+
+- Added support for **User API Key** parameter that the user api key (optional) to use for connection with doppel.

--- a/Packs/Doppel/ReleaseNotes/1_0_3.md
+++ b/Packs/Doppel/ReleaseNotes/1_0_3.md
@@ -2,5 +2,6 @@
 #### Integrations
 
 ##### Doppel
+- Updated the Docker image to: *demisto/python3:3.12.11.4819260*.
 
 - Added support for **User API Key** parameter that the user api key (optional) to use for connection with doppel.

--- a/Packs/Doppel/pack_metadata.json
+++ b/Packs/Doppel/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Doppel",
     "description": "This Content pack for Doppel mirrors the alerts created by Doppel as XSOAR incidents. The pack also contains the commands to perform different operations on Doppel alerts.",
     "support": "partner",
-    "currentVersion": "1.0.2",
+    "currentVersion": "1.0.3",
     "author": "Doppel Inc",
     "url": "https://www.doppel.com/",
     "email": "integrations@doppel.com",


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
This PR updates the Doppel integration in the Cortex XSOAR content pack to support authentication using an optional User API Key in addition to the existing API Key.

## Must have
- [ ] Tests
- [ ] Documentation 
